### PR TITLE
Fix template rendering in frontend, API url naming, add satellite listing POC

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,1 @@
+load-plugins=pylint_django

--- a/website/api/serializers.py
+++ b/website/api/serializers.py
@@ -20,10 +20,7 @@ class SatelliteSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Satellite
-        fields = ['owner', 'name', 'description', 'tles']
-        extra_kwargs = {
-            'owner': {'write_only': True},
-        }
+        fields = ['id', 'name', 'description', 'tles']
 
 
 class LocationSerializer(serializers.ModelSerializer):
@@ -32,7 +29,4 @@ class LocationSerializer(serializers.ModelSerializer):
     """
     class Meta:
         model = models.Location
-        fields = ['owner', 'name', 'latitude', 'longitude', 'elevation']
-        extra_kwargs = {
-            'owner': {'write_only': True},
-        }
+        fields = ['name', 'latitude', 'longitude', 'elevation']

--- a/website/api/urls.py
+++ b/website/api/urls.py
@@ -4,10 +4,10 @@ from rest_framework import routers
 from website.api import views
 
 router = routers.SimpleRouter()
-router.register(r'satellite', views.SatelliteViewSet)
-router.register(r'location', views.LocationViewSet)
+router.register(r'satellites', views.SatelliteViewSet)
+router.register(r'locations', views.LocationViewSet)
 
 urlpatterns = router.urls
 urlpatterns += [
-    path('satellite/<satellite_id>/predict_path/', views.predict_path),
+    path('satellites/<satellite_id>/predict_path/', views.predict_path),
 ]

--- a/website/static/website/client_templates/alert.html
+++ b/website/static/website/client_templates/alert.html
@@ -1,7 +1,0 @@
-<div class="alert alert-{{ alertType }} alert-dismissible fade show" role="alert">
-    <i class="fas fa-exclamation-circle"></i>
-    {{ message }}
-    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-        <i class="fas fa-times"></i>
-    </button>
-</div>

--- a/website/static/website/js/core.js
+++ b/website/static/website/js/core.js
@@ -13,8 +13,10 @@ var sateye = {
     initialize: function() {
         // initialize the whole client side app
         sateye.templates.alert = Handlebars.compile(document.getElementById("alert-template").innerHTML);
+        sateye.templates.satellite = Handlebars.compile(document.getElementById("satellite-template").innerHTML);
 
         sateye.dom.alertsBar = $("#alerts-bar");
+        sateye.dom.satelliteList = $("#satellite-list");
 
         sateye.map.initialize();
         sateye.satellites.initialize();
@@ -27,7 +29,7 @@ var sateye = {
     showAlert: function(alertType, message) {
         // show an alert for the user to see
         var newAlertContent = sateye.templates.alert({
-            alertType: alertType, 
+            alertType: alertType,
             message: message,
         });
         sateye.dom.alertsBar.append(newAlertContent);
@@ -70,10 +72,10 @@ var sateye = {
     },
 
     addSeconds: function(date, seconds) {
-        // add seconds to a julian date from cesium 
+        // add seconds to a julian date from cesium
         var newDate = new Cesium.JulianDate;
         Cesium.JulianDate.addSeconds(date, seconds, newDate);
-        return newDate
+        return newDate;
     },
 
     parseDate: function(iso8601string) {

--- a/website/static/website/js/map.js
+++ b/website/static/website/js/map.js
@@ -41,7 +41,7 @@ sateye.map = {
 
         // every some time, ensure we have paths for each satellite
         //sateye.map.mainMap.clock.onTick.addEventListener(sateye.map.onMapTick);
-        setInterval(sateye.map.ensurePathPredictions, 
+        setInterval(sateye.map.ensurePathPredictions,
                     sateye.map._predictionsRefreshRealSeconds * 1000);
 
         // remove fog and ground atmosphere on 3d globe
@@ -54,7 +54,7 @@ sateye.map = {
     },
 
     realToMapSeconds: function(realSeconds) {
-        // convert real seconds to map seconds, because the map can be moving at a different 
+        // convert real seconds to map seconds, because the map can be moving at a different
         // speed
         var clock = sateye.map.mainMap.clock;
         return clock.clockStep * clock.multiplier * realSeconds;
@@ -63,17 +63,17 @@ sateye.map = {
     ensurePathPredictions: function() {
         // ensure the map has enough info to display paths for shown satellites
 
-        // if we have less than X real seconds of predictions left, then ask for Y predicted 
+        // if we have less than X real seconds of predictions left, then ask for Y predicted
         // seconds
         // more info at docs/prediction_chunks.rst
         for (let satellite of sateye.satellites.active) {
             var currentDate = sateye.map.mainMap.clock.currentTime;
 
-            // we should ensure we have predictions enough to cover the time between the current date and 
+            // we should ensure we have predictions enough to cover the time between the current date and
             // currentDate + _predictionsTooLowThresholdRealSeconds
             var ensurePredictionsUntil = sateye.addSeconds(
                 currentDate,
-                sateye.map.realToMapSeconds(sateye.map._predictionsTooLowThresholdRealSeconds), 
+                sateye.map.realToMapSeconds(sateye.map._predictionsTooLowThresholdRealSeconds),
             );
 
             if (!satellite.predictionsCover(currentDate, ensurePredictionsUntil)) {

--- a/website/static/website/js/satellites.js
+++ b/website/static/website/js/satellites.js
@@ -2,8 +2,26 @@ sateye.satellites = {
     active: [],
 
     initialize: function() {
-        // TODO creating sample satellite, will replace with api later on
-        sateye.satellites.active.push(sateye.satellites.createSatellite(1, "iss"));
+        this.listSatellites();
+    },
+
+    listSatellites: function() {
+        var self = this;
+        return $.ajax({
+            url: "/api/satellites/",
+            cache: false,
+        }).done(function(data) {
+            for (var i = 0; i < data.length; i++) {
+                // Render satellites in list
+                var element = sateye.templates.satellite(data[i]);
+                console.log(element);
+                sateye.dom.satelliteList.append(element);
+
+                // Create paths in cesium map
+                var satellite = self.createSatellite(data[i].id, data[i].name);
+                self.active.push(satellite);
+            }
+        });
     },
 
     createSatellite: function(id, name) {
@@ -24,7 +42,7 @@ sateye.satellites = {
                 console.log("Requesting predictions for satellite " + this.name);
                 var self = this;
                 $.ajax({
-                    url: "/api/satellite/" + this.id + "/predict_path/",
+                    url: "/api/satellites/" + this.id + "/predict_path/",
                     cache: false,
                     data: {
                         start_date: startDate.toString(),

--- a/website/templates/website/client/alert.html
+++ b/website/templates/website/client/alert.html
@@ -1,0 +1,11 @@
+{% verbatim %}
+<script id="alert-template" type="text/x-handlebars-template">
+  <div class="alert alert-{{ alertType }} alert-dismissible fade show" role="alert">
+    <i class="fas fa-exclamation-circle"></i>
+    {{ message }}
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <i class="fas fa-times"></i>
+    </button>
+  </div>
+</script>
+{% endverbatim %}

--- a/website/templates/website/client/satellite.html
+++ b/website/templates/website/client/satellite.html
@@ -1,0 +1,22 @@
+{% verbatim %}
+<script id="satellite-template" type="text/x-handlebars-template">
+  <h3>{{ name }}</h3>
+  <p>{{ description }}</p>
+  <table class="table">
+    <thead>
+      <tr>
+        <th scope="col">Recorded at</th>
+        <td scope="col">TLE</td>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each tles}}
+      <tr>
+        <th scope="row">{{ this.at }}</th>
+        <td scope="row">{{ this.lines }}</th>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</script>
+{% endverbatim %}

--- a/website/templates/website/home.html
+++ b/website/templates/website/home.html
@@ -61,7 +61,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.1.0/handlebars.min.js" crossorigin="anonymous"></script>
     <script src="http://cesiumjs.org/releases/1.54/Build/Cesium/Cesium.js" crossorigin="anonymous"></script>
 
-    <script id="alert-template" type="text/x-handlebars-template" src="{% static 'website/client_templates/alert.html' %}"></script>
+    {% include "website/client/alert.html" %}
+    {% include "website/client/satellite.html" %}
 
     <script src="{% static 'website/js/core.js' %}"></script>
     <script src="{% static 'website/js/map.js' %}"></script>

--- a/website/templates/website/satellites.html
+++ b/website/templates/website/satellites.html
@@ -2,3 +2,4 @@
     <i class="fas fa-rocket"></i>
     Satellites
 </h2>
+<div id="satellite-list"></div>

--- a/website/templates/website/side_menu.html
+++ b/website/templates/website/side_menu.html
@@ -10,7 +10,7 @@
             <li class="nav-item">
                 <a class="nav-link" data-toggle="pill" href="#tab-satellites" role="tab">
                     <i class="fas fa-rocket fa-fw"></i>
-                    Satellites 
+                    Satellites
                     <span class="badge badge-secondary">4</span>
                 </a>
             </li>


### PR DESCRIPTION
- Moved template rendering outside of static files handling (for some reason it was returning an empty string instead of the expected inner HTML)
- API url naming: according to REST API conventions base resource names must be plural
- Add satellite listing proof-of-concept: The frontend is now retrieving all available satellites from the API and creating markers in the map. Also, there is a basic data listing of these satellites in the "Satellite" tab in the sidebar. I assume a creation/edition form will be expected at some point?