### PR TITLE
Add basic pass listing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ __pycache__
 *.sqlite3
 env
 .idea
-
+tags
+.pylintrc

--- a/website/api/serializers.py
+++ b/website/api/serializers.py
@@ -89,7 +89,9 @@ class PassSerializer(serializers.Serializer):
     """
     Serializer for the pass prediction endpoint.
     """
-    max_elevation_degrees = serializers.FloatField(source='max_elevation_deg')
+    max_elevation_degrees = serializers.DecimalField(
+        max_digits=5, decimal_places=2, source='max_elevation_deg'
+    )
     max_elevation_date = serializers.DateTimeField()
     aos = serializers.DateTimeField()
     los = serializers.DateTimeField()

--- a/website/static/website/js/core.js
+++ b/website/static/website/js/core.js
@@ -4,22 +4,31 @@ var Alert = {
     ERROR: "error"
 }
 
+var templatesMap = {
+    alert: "#alert-template",
+    satellite: "#satellite-template",
+    passList: "#pass-list-template",
+};
+
 var sateye = {
     templates: {},
     dom: {},
 
     initialize: function() {
-        // initialize the whole client side app
-        sateye.templates.alert = Handlebars.compile(document.getElementById("alert-template").innerHTML);
-        sateye.templates.satellite = Handlebars.compile(document.getElementById("satellite-template").innerHTML);
+        // compile templates
+        for (name in templatesMap) {
+            sateye.templates[name] = Handlebars.compile($(templatesMap[name]).html());
+        }
 
         // references to the dom
         sateye.dom.alertsBar = $("#alerts-bar");
+        sateye.dom.passList = $("#pass-list");
 
         // initialize submodules
         sateye.map.initialize();
         sateye.satellites.initialize();
         sateye.locations.initialize();
+        sateye.passes.initialize();
         sateye.dashboards.initialize();
     },
 

--- a/website/static/website/js/map.js
+++ b/website/static/website/js/map.js
@@ -69,7 +69,7 @@ sateye.map = {
     },
 
     onNewLocations: function(locations) {
-        // add new locations to the map 
+        // add new locations to the map
         for (let location of locations) {
             var locationEntity = {
                 id: "Sateye.Location:" + location.id,

--- a/website/static/website/js/passes.js
+++ b/website/static/website/js/passes.js
@@ -1,0 +1,28 @@
+sateye.passes = {
+  dom: {},
+
+  initialize: function() {
+    sateye.passes.dom.passList = $("#pass-list");
+    sateye.passes.predictPasses("2019-03-14", "2019-03-15", 1);
+  },
+
+  predictPasses: function(startDate, endDate, locationId) {
+    var self = this;
+    var params = {
+      start_date: startDate,
+      end_date: endDate,
+      location: locationId,
+    };
+
+    $.ajax({
+      url: "/api/satellites/1/predict_passes/",
+      cache: false,
+      data: params,
+    }).done(function(data) { self.onPassesRetrieved(data) });
+  },
+
+  onPassesRetrieved: function(data) {
+    var content = sateye.templates.passList({passes: data});
+    sateye.dom.passList.html(content);
+  },
+};

--- a/website/static/website/js/satellites.js
+++ b/website/static/website/js/satellites.js
@@ -56,7 +56,7 @@ sateye.satellites = {
 
     onExistingSatelliteClicked: function(e) {
         // the user clicked an existing satellite to add it to the dashboard
-        var self = $(this); 
+        var self = $(this);
         console.log('clicked:');
         console.log(self);
         var satelliteId = self.data("satelliteId");

--- a/website/templates/website/client/passes.html
+++ b/website/templates/website/client/passes.html
@@ -1,0 +1,15 @@
+{% verbatim %}
+<script id="pass-list-template" type="text/x-handlebars-template">
+    <ul class="list-group">
+    {{#each passes}}
+        <li class="list-group-item">
+            <ul>
+            <li>AOS: {{ this.aos }}</li>
+            <li>LOS: {{ this.los }}</li>
+            <li>TCA: {{ this.max_elevation_degrees }}° at {{ this.max_elevation_date }}</li>
+            </ul>
+        </li>
+    {{/each}}
+    </ul>
+</script>
+{% endverbatim %}

--- a/website/templates/website/home.html
+++ b/website/templates/website/home.html
@@ -26,7 +26,7 @@
         </div>
         <div class="row">
             <div id="alerts-bar"></div>
-            <div class="col p-0 tab-content">
+            <div class="col tab-content">
                 {% include 'website/map.html' %}
             </div>
         </div>
@@ -45,11 +45,13 @@
 
     {% include "website/client/alert.html" %}
     {% include "website/client/satellite.html" %}
+    {% include "website/client/passes.html" %}
 
     <script src="{% static 'website/js/core.js' %}"></script>
     <script src="{% static 'website/js/map.js' %}"></script>
     <script src="{% static 'website/js/satellites.js' %}"></script>
     <script src="{% static 'website/js/locations.js' %}"></script>
+    <script src="{% static 'website/js/passes.js' %}"></script>
     <script src="{% static 'website/js/dashboards.js' %}"></script>
 
     <script src="{% static 'website/js/home.js' %}"></script>

--- a/website/templates/website/map.html
+++ b/website/templates/website/map.html
@@ -1,16 +1,8 @@
 <div id="main-map-container" class="row">
-    <div class="col-2">
-        <h4>
-            <i class="fas fa-binoculars"></i>
-            Passes
-        </h4>
-        <p>a pass</p>
-        <p>a pass</p>
-        <p>a pass</p>
-    </div>
+    <div id="pass-list" class="col-2 p-0"></div>
     <div class="col-10">
         <div class="row">
-            <div id="main-map" class="col-12"></div>
+            <div id="main-map" class="col-12 p-0"></div>
             <div id="main-map-controls" class="col-12 btn-group-toggle" data-toggle="buttons">
                 <input id="night-shadow-input" type="checkbox" data-toggle="toggle" data-on="Day/Night" data-off="No shadow" data-size="sm">
             </div>

--- a/website/templates/website/navbar.html
+++ b/website/templates/website/navbar.html
@@ -1,11 +1,11 @@
 {% load static %}
 
 <nav class="navbar navbar-dark navbar-expand-md bg-dark col-sm-12 p-0">
-    <a class="navbar-brand col-sm-1" href="#">
+    <a class="navbar-brand col-2" href="#">
         <img src="{% static 'website/img/logo_big.png' %}" width="30" height="30" />
         SatEye
     </a>
-    <div class="collapse navbar-collapse col-sm-11">
+    <div class="collapse navbar-collapse col-10">
         <ul class="nav navbar-nav">
             <li class="nav-item">
                 <a class="nav-link" data-toggle="modal" data-target="#satellites-modal" href="#satellites-modal">


### PR DESCRIPTION
New:
- Passes listing now shown on left side of screen (only for satellite id: 1 and location id: 1)
- Minor styling tweaks for map alignment with navbar

Possible ideas:
- Click on pass list item zooms in on location marker and moves clock to `aos` datetime
- Add scroll bar
- Collapsable tree display? (Satellite>Passes or Location>Passes or Location>Satellite>Passes...? etc)

Issues:
- Map mantains a fixed ratio when resized
- Small padding to the right of map makes horizontal scroll bar to appear